### PR TITLE
Add new variants

### DIFF
--- a/download-files/Lockout_RockyRoad.json
+++ b/download-files/Lockout_RockyRoad.json
@@ -744,7 +744,7 @@
         "binoculars"
       ]
     },
-{ "name": "Use 8 Binoculars among 7A, 7B, ad 7C" },
+{ "name": "Use 8 Binoculars among 7A, 7B, and 7C" },
     {
       "name": "10 Berries in 3 Chapters",
       "types": [

--- a/download-files/SJ.json
+++ b/download-files/SJ.json
@@ -28,7 +28,6 @@
 		{"name": "5 Berries", "types": ["berries"]}
 	],
 	[
-		{"name": "Pet Troposphere Cat", "types": ["cat"]},
 		{"name": "Pet Strawberry Orchard Cat", "types": ["cat"]},
 		{"name": "Complete Troposphere", "types": []},
 		{"name": "Complete Switchtube Vista", "types": []},
@@ -58,7 +57,6 @@
 	[
 		{"name": "Interract Wtih All Benches in Beginner Lobby", "types": []},
 		{"name": "Pet Crab Lobby Cat", "types": ["cat"]},
-		{"name": "Pet Frosted Fragments Cat", "types": ["cat"]},
 		{"name": "5 Hearts", "types": ["hearts"]},
 		{"name": "Complete Seeing is Believing", "types": []},
 		{"name": "Complete Soap", "types": []},
@@ -106,6 +104,7 @@
 		{"name": "5 Intermediate Berries", "types": ["berries"]}
 	],
 	[
+		{"name": "Pet Frosted Fragments Cat", "types": ["cat"]},
 		{"name": "Use all 5 keys in Honeyzip Inc.", "types": []},
 		{"name": "Reach 'Tranquility' in Blueberry Bay", "types": ["heartside"]},
 		{"name": "Complete Honeyzip Inc.", "types": []},
@@ -149,13 +148,13 @@
 		{"name": "Complete Square the Circle", "types": []},
 		{"name": "Complete Temple of a Thousand Skies", "types": []},
 		{"name": "Complete Golden Dawn", "types": ["advanced"]},
-		{"name": "All Berries in EAT GIRL (2)", "types": ["berries"]},
-		{"name": "All Berries in In Filtration (5)", "types": ["berries"]},
 		{"name": "All Berries in Construction Conundrum (2)", "types": ["berries"]},
 		{"name": "All Berries in Temple of a Thousand Skies (4)", "types": ["berries"]},
 		{"name": "Royal Pizza room in Starlight Station", "types": ["advanced"]}
 	],
 	[
+		{"name": "All Berries in EAT GIRL (2)", "types": ["berries"]},
+		{"name": "All Berries in In Filtration (5)", "types": ["berries"]},
 		{"name": "Complete Starry Ruins", "types": ["advanced"]},
 		{"name": "Complete Jellyfish Sanctum", "types": ["advanced"]},
 		{"name": "Complete Forest Rush", "types": ["advanced"]},
@@ -227,13 +226,13 @@
 		{"name": "5 Berries in 3 Lobbies", "types": ["berries"]}
 	],
 	[
-		{"name": "Talk to Theo in BVD ( After final room )", "types": ["advanced"]},
+		{"name": "Talk to Theo in BVD (After final room)", "types": ["advanced"]},
 		{"name": "Pet Mango Mesa First Cat", "types": ["heartside","advanced","cat"]},
 		{"name": "Complete Call of the Void", "types": ["advanced"]},
-		{"name": "All Berries in Call of the Void (5)", "types": ["advanced","berries"]},
 		{"name": "10 Advanced Berries", "types": ["advanced","berries"]}
 	],
 	[
+		{"name": "All Berries in Call of the Void (5)", "types": ["advanced","berries"]},
 		{"name": "Reach 'Petrichor' in Raspberry Roots", "types": ["heartside"]},
 		{"name": "3 Advanced Hearts", "types": ["advanced","hearts"]},
 		{"name": "All Berries in Undergrowth (5)", "types": ["berries","advanced"]},

--- a/download-files/SJ.json
+++ b/download-files/SJ.json
@@ -1,0 +1,249 @@
+[
+	[
+		{"name": "Complete Forest Path", "types": []},
+		{"name": "Complete Azure Caverns", "types": []},
+		{"name": "Complete Loopy Lagoon", "types": []},
+		{"name": "Complete Driveway", "types": []},
+		{"name": "Complete Treehive", "types": []},
+		{"name": "All Berries in Azure Caverns (2)", "types": ["berries"]}
+	],
+	[
+		{"name": "Grabless Forest Path", "types": ["grabless"]},
+		{"name": "Grabless Azure Caverns", "types": ["grabless"]},
+		{"name": "Grabless Driveway", "types": ["grabless"]},
+		{"name": "Complete Rose Garden", "types": []},
+		{"name": "Complete The Squeeze", "types": []},
+		{"name": "All Berries in Forest Path (4)", "types": ["berries"]},
+		{"name": "All Berries in Driveway (3)", "types": ["berries"]},
+		{"name": "All Berries in The Squeeze (2)", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet Bamboo Lobby Cat", "types": ["cat"]},
+		{"name": "2 Levels Grabless", "types": ["grabless"]},
+		{"name": "Complete Collapsing Skyline", "types": []},
+		{"name": "Complete Over the City", "types": []},
+		{"name": "All Berries in Loopy Lagoon (3)", "types": ["berries"]},
+		{"name": "All Berries in Collapsing Skyline (3)", "types": ["berries"]},
+		{"name": "All Berries in Treehive (2)", "types": ["berries"]},
+		{"name": "5 Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet Troposphere Cat", "types": ["cat"]},
+		{"name": "Pet Strawberry Orchard Cat", "types": ["cat"]},
+		{"name": "Complete Troposphere", "types": []},
+		{"name": "Complete Switchtube Vista", "types": []},
+		{"name": "Complete A Gift From the Stars", "types": []},
+		{"name": "All Berries in Troposphere (1)", "types": ["berries"]}
+	],
+	[
+		{"name": "Intro car house in Seeing is Believing", "types": []},
+		{"name": "Key Secret in paint", "types": []},
+		{"name": "Complete Strawberry Orchard", "types": []},
+		{"name": "Complete Coresaken City", "types": []},
+		{"name": "All Berries in Over the City (3)", "types": ["berries"]},
+		{"name": "All Berries in Potential for Anything (3)", "types": ["berries"]},
+		{"name": "All Berries in paint (4)", "types": ["berries"]},
+		{"name": "All Berries in Switchtube Vista (5)", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet 3 Cats", "types": ["cat"]},
+		{"name": "Complete Potential for Anything", "types": []},
+		{"name": "Complete paint", "types": []},
+		{"name": "All Berries in A Gift From the Stars (5)", "types": ["berries"]},
+		{"name": "All Berries in Strawberry Orchard (5)", "types": ["berries"]},
+		{"name": "All Berries in Coresaken City (3)", "types": ["berries"]},
+		{"name": "10 Berries", "types": ["berries"]},
+		{"name": "10 Beginner Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "Interract Wtih All Benches in Beginner Lobby", "types": []},
+		{"name": "Pet Crab Lobby Cat", "types": ["cat"]},
+		{"name": "Pet Frosted Fragments Cat", "types": ["cat"]},
+		{"name": "5 Hearts", "types": ["hearts"]},
+		{"name": "Complete Seeing is Believing", "types": []},
+		{"name": "Complete Soap", "types": []},
+		{"name": "Complete Dropzle", "types": []},
+		{"name": "All Berries in Seeing is Believing (1)", "types": ["berries"]},
+		{"name": "All Berries in Cassette Cliffs (2)", "types": ["berries"]}
+	],
+	[
+		{"name": "Seeing is Believing Single-Player Mode", "types": []},
+		{"name": "6 Beginner Hearts", "types": ["hearts"]},
+		{"name": "Complete Midnight Spire", "types": []},
+		{"name": "Complete Fifth Dimension", "types": []},
+		{"name": "All Berries in Midnight Spire (4)", "types": ["berries"]},
+		{"name": "All Berries in Dropzle (5)", "types": ["berries"]},
+		{"name": "5 Berries in 2 Maps", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet Blueberry Bay Lobby Cat", "types": ["cat"]},
+		{"name": "Pet 5 Cats", "types": ["cat"]},
+		{"name": "Complete Cassette Cliffs", "types": []},
+		{"name": "Complete Sleeping Under Stars", "types": []},
+		{"name": "Complete Frosted Fragments", "types": []},
+		{"name": "All Berries in Soap (5)", "types": ["berries"]},
+		{"name": "All Berries in Sleeping Under Stars (1)", "types": ["berries"]},
+		{"name": "All Berries in Frosted Fragments (2)", "types": ["berries"]},
+		{"name": "All Berries in Low-G Botany (3)", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet Intermediate Lobby Cat", "types": ["cat"]},
+		{"name": "Grabless Cassette Cliffs", "types": ["grabless"]},
+		{"name": "Reach 'Basin' in Blueberry Bay", "types": ["heartside"]},
+		{"name": "Complete Low-G Botany", "types": []},
+		{"name": "Complete Deep Blue", "types": []},
+		{"name": "Complete Pointless Machines", "types": []},
+		{"name": "All Berries in Deep Blue (3)", "types": ["berries"]},
+		{"name": "All Berries in Pointless Machines (2)", "types": ["berries"]},
+		{"name": "15 Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "15 Beginner Berries", "types": ["berries"]},
+		{"name": "Grabless Low-G Botany", "types": ["grabless"]},
+		{"name": "Complete Midnight Monsoon", "types": []},
+		{"name": "All Berries in Honeyzip Inc. (3)", "types": ["berries"]},
+		{"name": "All Berries in Supernautica (2)", "types": ["berries"]},
+		{"name": "5 Intermediate Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "Use all 5 keys in Honeyzip Inc.", "types": []},
+		{"name": "Reach 'Tranquility' in Blueberry Bay", "types": ["heartside"]},
+		{"name": "Complete Honeyzip Inc.", "types": []},
+		{"name": "Complete Supernautica", "types": []},
+		{"name": "All Berries in Midnight Monsoon (3)", "types": ["berries"]},
+		{"name": "5 Berries in 2 Lobbies", "types": ["berries"]}
+	],
+	[
+		{"name": "Pet 7 Cats", "types": ["cat"]},
+		{"name": "Complete Sea of Soup", "types": []},
+		{"name": "Complete Vertigo", "types": []},
+		{"name": "Complete The Tower", "types": []},
+		{"name": "Complete Pufferfish Transportation Co.", "types": []},
+		{"name": "All Berries in The Tower (3)", "types": ["berries"]},
+		{"name": "20 Berries", "types": ["berries"]},
+		{"name": "5 Berries in 3 Maps", "types": ["berries"]}
+	],
+	[
+		{"name": "Sea of Soup dashless", "types": []},
+		{"name": "Reach 'Jade' in Blueberry Bay", "types": ["heartside"]},
+		{"name": "4 Intermediate Hearts", "types": ["hearts"]},
+		{"name": "All Berries in Sea of Soup (5)", "types": ["berries"]},
+		{"name": "All Berries in Pufferfish Transportation Co. (5)", "types": ["berries"]},
+		{"name": "20 Beginner Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "10 Hearts", "types": ["hearts"]},
+		{"name": "9 Beginner Hearts", "types": ["hearts"]},
+		{"name": "Complete In Filtration", "types": []},
+		{"name": "Complete Construction Conundrum", "types": []},
+		{"name": "Complete Lethal Laser Laboratory", "types": ["advanced"]},
+		{"name": "10 Intermediate Berries", "types": ["berries"]},
+		{"name": "10 Berries in 2 Lobbies", "types": ["berries"]},
+		{"name": "Pet Cloud Lobby Cat", "types": ["advanced","cat"]},
+		{"name": "Pet Cellar Lobby Cat", "types": ["advanced","cat"]},
+		{"name": "1 Advanced Map", "types": ["advanced"]}
+	],
+	[
+		{"name": "Reach 'Overgrowth' in Blueberry Bay", "types": ["heartside"]},
+		{"name": "Complete EAT GIRL", "types": []},
+		{"name": "Complete Square the Circle", "types": []},
+		{"name": "Complete Temple of a Thousand Skies", "types": []},
+		{"name": "Complete Golden Dawn", "types": ["advanced"]},
+		{"name": "All Berries in EAT GIRL (2)", "types": ["berries"]},
+		{"name": "All Berries in In Filtration (5)", "types": ["berries"]},
+		{"name": "All Berries in Construction Conundrum (2)", "types": ["berries"]},
+		{"name": "All Berries in Temple of a Thousand Skies (4)", "types": ["berries"]},
+		{"name": "Royal Pizza room in Starlight Station", "types": ["advanced"]}
+	],
+	[
+		{"name": "Complete Starry Ruins", "types": ["advanced"]},
+		{"name": "Complete Jellyfish Sanctum", "types": ["advanced"]},
+		{"name": "Complete Forest Rush", "types": ["advanced"]},
+		{"name": "Complete Toggle Theory", "types": ["advanced"]},
+		{"name": "All Berries in Square the Circle (5)", "types": ["berries"]},
+		{"name": "All Berries in Lethal Laser Laboratory (1)", "types": ["berries"]},
+		{"name": "All Berries in Jellyfish Sanctum (1)", "types": ["berries"]},
+		{"name": "Reach OWO Room in Square the Circle", "types": []}
+	],
+	[
+		{"name": "Interract Wtih All Benches in Intermediate Lobby", "types": []},
+		{"name": "Reach 'Harbor' in Blueberry Bay", "types": ["heartside"]},
+		{"name": "Complete Sands of Time", "types": ["advanced"]},
+		{"name": "Complete Lost Woods", "types": ["advanced"]},
+		{"name": "Complete Tectonic Trenches", "types": ["advanced"]},
+		{"name": "Complete Attack of the Clone", "types": ["advanced"]},
+		{"name": "Complete Thinking with Portals", "types": ["advanced"]},
+		{"name": "All Berries in Tectonic Trenches (2)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Golden Dawn (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Forest Rush (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Belated Valentine's Day (2)", "types": ["advanced","berries"]}
+	],
+	[
+		{"name": "Pet 9 Cats", "types": ["cat"]},
+		{"name": "Reach 'Phloem' in Raspberry Roots", "types": ["heartside"]},
+		{"name": "Complete Slime Time!", "types": ["advanced"]},
+		{"name": "Complete Java's Crypt", "types": ["advanced"]},
+		{"name": "Complete Rightside-Down Cavern", "types": ["advanced"]},
+		{"name": "All Berries in Sands of Time (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Slime Time! (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Attack of the Clone (1)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Toggle Theory (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Superstructure (1)", "types": ["advanced","berries"]},
+		{"name": "30 Berries", "types": ["berries"]}
+	],
+	[
+		{"name": "Interract Wtih All Benches in Advanced Lobby", "types": ["advanced"]},
+		{"name": "Pet Blueberry Bay Cat", "types": ["heartside","cat"]},
+		{"name": "Pet Starlight Station Cat", "types": ["advanced","cat"]},
+		{"name": "Pet Rightside-Down Cavern Cat", "types": ["advanced","cat"]},
+		{"name": "Complete Blueberry Bay", "types": ["heartside"]},
+		{"name": "6 Intermediate Hearts", "types": ["hearts"]},
+		{"name": "Complete Belated Valentine's Day", "types": ["advanced"]},
+		{"name": "All Berries in Synapse (1)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Thinking with Portals (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Rightside-Down Cavern (3)", "types": ["advanced","berries"]},
+		{"name": "15 Intermediate Berries", "types": ["berries"]},
+		{"name": "5 Advanced Berries", "types": ["advanced","berries"]}
+	],
+	[
+		{"name": "Reach 'Mycelium' in Raspberry Roots", "types": ["heartside"]},
+		{"name": "Complete Undergrowth", "types": ["advanced"]},
+		{"name": "Complete Superstructure", "types": ["advanced"]},
+		{"name": "Complete Starlight Station", "types": ["advanced"]},
+		{"name": "Complete Dusk City", "types": ["advanced"]},
+		{"name": "Complete Synapse", "types": ["advanced"]},
+		{"name": "Complete The Lab", "types": ["advanced"]},
+		{"name": "All Berries in Lost Woods (1)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Java's Crypt (5)", "types": ["advanced","berries"]}
+	],
+	[
+		{"name": "2 Advanced Hearts", "types": ["advanced","hearts"]},
+		{"name": "Complete Bee Berserk", "types": ["advanced"]},
+		{"name": "Complete Raindrops on Roses", "types": ["advanced"]},
+		{"name": "Complete The Tower (XVI)", "types": ["advanced"]},
+		{"name": "All Berries in Bee Berserk (1)", "types": ["advanced","berries"]},
+		{"name": "All Berries in Starlight Station (3)", "types": ["advanced","berries"]},
+		{"name": "All Berries in The Lab (3)", "types": ["advanced","berries"]},
+		{"name": "5 Berries in 3 Lobbies", "types": ["berries"]}
+	],
+	[
+		{"name": "Talk to Theo in BVD ( After final room )", "types": ["advanced"]},
+		{"name": "Pet Mango Mesa First Cat", "types": ["heartside","advanced","cat"]},
+		{"name": "Complete Call of the Void", "types": ["advanced"]},
+		{"name": "All Berries in Call of the Void (5)", "types": ["advanced","berries"]},
+		{"name": "10 Advanced Berries", "types": ["advanced","berries"]}
+	],
+	[
+		{"name": "Reach 'Petrichor' in Raspberry Roots", "types": ["heartside"]},
+		{"name": "3 Advanced Hearts", "types": ["advanced","hearts"]},
+		{"name": "All Berries in Undergrowth (5)", "types": ["berries","advanced"]},
+		{"name": "15 Hearts", "types": ["hearts"]}
+	],
+	[
+		{"name": "All Berries in Raindrops on Roses (4)", "types": ["berries"]},
+		{"name": "Complete Raspberry Roots", "types": ["heartside"]},
+		{"name": "40 Berries", "types": ["berries"]},
+		{"name": "10 Berries in 3 Lobbies", "types": ["berries","advanced"]},
+		{"name": "Reach 'Crest' in Mango Mesa", "types": ["heartside","advanced"]}
+	]
+]

--- a/variant-list.js
+++ b/variant-list.js
@@ -37,7 +37,7 @@ let variant_list_data = [
     },
     {
         name: "Fog of War",
-        credit: "Dragon512, plugin developed by Cirion, Rhuan, ported into Celeste Bingosync by crab",
+        credit: "Dragon, plugin developed by Cirion, Rhuan, ported into Celeste Bingosync by crab",
         description: "A variant of blackout (teams or solo) in which only the lowest-tier objective on the 5x5 board is revealed at the start, and as players tick objectives on the bingo board, adjacent objectives are revealed. Standard blackout rules apply.",
         color:"White",
         tags:["blackout"],
@@ -1231,7 +1231,7 @@ let variant_list_data = [
     },
     {
         name: "Trackmania Bingo",
-        credit: "Cirion, Generator by creep.",
+        credit: "Cirion, Generator by creep",
         description: "A bingo board with 25 ILs (or checkpoints) on it is created. 2 teams fight to get one or two complete lines on the board. To tick off a square for the first time, a player must beat that IL, and note their time for completing it. Any player on either team can then steal that square by completing the IL in a faster time, also lowering the time needed to steal that square again.",
         notes: "Use the Randomized setting to create a board, not the srlv5 setting. There is no way of keeping track of IL times without recording the time externally.",
         color:"Orange",
@@ -1393,6 +1393,252 @@ let variant_list_data = [
         tags:["lockout", "custom-generator", "difficult", "long"],
         min_teams:1,
         max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Dementiago",
+        credit: "ilikerandom, named 'dementiago' by ad",
+        description: "A variant of blackout in which each objective ticked hides adjacent objectives. Players must instantly tick an objective they believe to have: if that objective is not something they have, they must untick the objective and wait in place for 1 minute. Standard blackout rules apply.",
+        notes: "No such plugin currently exists.",
+        color:"Red",
+        tags:["blackout", "cursed", "unplayable"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Kryptingo",
+        credit: "bulletinfi",
+        description: "A more strict version of ktango in which routers must speak in cryptic clues.",
+        color:"Orange",
+        tags:["lockout", "ktango", "cursed"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:2,
+        max_players_per_team:2
+    },
+    {
+        name: "Signalgo",
+        credit: "idontexist",
+        description: "An unbalanced variant of lockout bingo in which Player A must signal an objective they have for an agreed amount of time before they get the objective. Player B can steal signaled objectives within the timeframe that is agreed.", 
+        color:"Orange",
+        tags:["lockout"], 
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Disconnectedgo",
+        credit: "Morraconda",
+        description: "A variant of lockout in which players cannot tick any objective orthogonally adjacent to an objective they have already ticked. If a player does not have any valid ticks, any objectives may be ticked by that player. First to 13 wins. ",
+        color:"Orange",
+        tags:["lockout"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "How to Lose at Bingo (HTLAB)",
+        credit: "Random Name",
+        description: "An variant of lockout in which both players get a random debuff.",
+        notes: "This variant can also be used to balance skill gaps by having the better player play with a debuff and the other play standard lockout.",
+        color:"Green",
+        tags:["lockout", "cursed"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Bingo B-Side",
+        credit: "FlyingLudicolo",
+        description: "A variant of lockout in which every objective is altered so that the objective has to be completed in a specific way or changed to be a more difficult version.",
+        notes: "No such generator exists.",
+        color:"Red",
+        tags:["lockout", "custom-generator", "cursed", "difficult", "unplayable"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Bingo but it's actually bingo",
+        credit: "ArrowBounce",
+        description: "Each player (spectator) generates a bingo board during a livestreamed event. Players (spectator) tick objectives when a player (on stream) completes an objective on the player's (spectator) board. First to reach a pre-determined goal (e.g. 1 line, 3 line, blackout) wins.",
+        color:"Red",
+        tags:["blackout", "cursed"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Soulreadgo",
+        credit: "Cirion, Random Name independently",
+        description: "A variant of lockout in which players may call a soulread and tick an objective they think their opponent is delaying. If correct, you keep the tick without having to complete the objective yourself, otherwise the opponent gets the tick.",
+        notes: "A variation forces all objectives completed to be delayed by an agreed amount of time. Soulreadgo has been suggested in a ktango format, soulreadktango, with a time penalty for an incorrect soulread.", 
+        color:"Orange",
+        tags:["lockout", "ktango"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:2
+    },
+    {
+        name: "Pictionary Ktango",
+        credit: "jan",
+        description: "A more strict version of ktango in which routers must draw pictures without using any words.",
+        color:"Green",
+        tags:["lockout", "ktango", "blackout"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:2,
+        max_players_per_team:2
+    },
+    {
+        name: "One word Ktango",
+        credit: "Random Name",
+        description: "A more strict version of ktango which routers may say exactly one word per objective tick.",
+        color:"Orange",
+        tags:["lockout", "ktango", "cursed"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:2,
+        max_players_per_team:2
+    },
+    {
+        name: "Wheel of Fortune",
+        credit: "rhelmot",
+        description: "A variant of lockout in which every character is replaced with *. Every n seconds, players may submit one character for an individual square to reveal those characters. If a player ticks an objective they don't have, the tick goes to the opponent.",
+        notes: "No such plugin currently exists. Creator suggests combining this gamemode with bingobuthardtoread.",
+        color:"Red",
+        external_links:[{
+            name:"Generator",
+            file:"download-files/bingobuthardtoread.json"
+        }],
+        tags:["lockout", "custom-generator", "cursed", "unplayable"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Fog Reveal or Scoutout",
+        credit: "PocketWraith",
+        description: "A variant of fog of war with the goal to achieve full board vision.",
+        color:"Blue",
+        tags:["blackout"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Capture the Square",
+        credit: "creep",
+        description: "Two players play on five boards forming a plus sign (+). There are two phases to this game: the Control phase and the Capture phase. During the Control phase, the outer boards are played with Line Control (Row Control for left and right boards, Column Control for the top and bottom boards). For each line controlled, the adjacent square on the central board becomes \"protected\" (opponent cannot capture). Players can choose to complete and tick these protected squares at any moment. The Capture phase begins when all outer boards have no more free rows. All remaining objectives on the central board become unprotected and is played as a modified cheat mode lockout game from a fresh save file. First to tick 13 objectives on the central board wins.",
+        notes: "If a corner square is doubly protected by the same player, the tick goes to the player without having to complete the objective. If protected by both, then the square can be ticked by either player. Extremely difficult to manage 5 boards concurrently.",
+        color:"Red",
+        tags:["lockout", "cursed", "difficult", "unplayable"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Sunny Reveal", 
+        credit: "Random Name, named 'sunny reveal' by OliviaPG",
+        description: "A variant of blackout in which objectives are ticked or orthogonally touching a ticked objective. Ticked objectives must be orthogonally connected starting from (and including) the T1 objective by the end of the game.",
+        color:"Green",
+        tags:["blackout"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Strawberry Jam Bingo",
+        credit: "Tntgobang, maintained by Tntgobang, Nene22, creep, Cookie",
+        description: "A variant of lockout bingo played on the 2023 Strawberry Jam mod.",
+        notes: "There is a known bug with the custom progression mod that says the mod assembly failed to load. You can safely ignore this error. Do not use BingoUI with Strawberry Jam Bingo.",
+        color:"Green",
+        external_links:[
+            {
+                name: "Custom Progression",
+                link: "https://gamebanana.com/mods/495570"
+            },
+            {
+                name: "Ruleset",
+                link: "https://discord.com/channels/529677942393929749/689529939975864453/1207015327008038962"
+            },
+            {
+                name: "Generator",
+                file: "download-files/SJ.json"
+            }
+        ],
+        tags:["lockout", "custom-generator"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Alphabetgo",
+        credit: "ArrowBounce",
+        description: "A more strict version of ktango in which routers have to start each word/sentence with the letter following the letter that started the previous one.",
+        color:"Orange",
+        tags:["lockout", "ktango", "cursed"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:2,
+        max_players_per_team:2
+    },
+    {
+        name: "Control Swap",
+        credit: "creep",
+        description: "A variant of lockout in which players switch control schemes and binds.",
+        notes: "A study of this style took place during November 2023.",
+        color:"Green",
+        tags:["lockout", "cursed", "difficult"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:1,
+        max_players_per_team:1
+    },
+    {
+        name: "Cluelessgo",
+        credit: "ilikerandom",
+        description: "A variant of lockout (2v2) but teammates are not allowed to communicate.",
+        color:"Orange",
+        tags:["lockout"],
+        min_teams:2,
+        max_teams:2,
+        min_players_per_team:2,
+        max_players_per_team:2
+    },
+    {
+        name: "Guesswork",
+        credit: "bulletinfi, named 'guesswork' by creep",
+        description: "A variant of blackout in which the board is not visible to the player. Using Bingoclient's autoclaim feature, players keep track of the amount of times \"objective x is claimable\". Play until n objectives.",
+        color:"Orange",
+        tags:["blackout", "cursed"],
+        min_teams:1,
+        max_teams:null,
+        min_players_per_team:1,
+        max_players_per_team:null
+    },
+    {
+        name: "Bingo with Stream Sniping",
+        credit: "bulletinfi",
+        description: "A variant of lockout in which players can watch each other's streams.",
+        color:"Orange",
+        tags:["lockout"],
+        min_teams:2,
+        max_teams:2,
         min_players_per_team:1,
         max_players_per_team:null
     }

--- a/variant-list.js
+++ b/variant-list.js
@@ -1366,6 +1366,10 @@ let variant_list_data = [
         description: "An identical ruleset to Chessgo, except played on a board of Go.",
         notes: "Use the Individual Berry Bingo generator. Playing with cheat mode is recommended. A board size of 9 is recommended for readability. ",
         color:"Green",
+        external_links:[{
+            name:"Generator",
+            file:"download-files/individual_berry_bingo.json",
+        }],
         tags:["lockout", "cursed"],
         min_teams:2,
         max_teams:2,

--- a/variant-list.js
+++ b/variant-list.js
@@ -1134,7 +1134,7 @@ let variant_list_data = [
         color:"Orange",
         external_links:[{
             name:"Detailed Ruleset",
-            link:"https://discord.com/channels/529677942393929749/689529939975864453/1023348808836464681",
+            link:"https://discord.com/channels/529677942393929749/689529939975864453/1055112961833848852",
         }],
         tags:["cursed"],
         min_teams:2,

--- a/variant-list.js
+++ b/variant-list.js
@@ -1401,7 +1401,7 @@ let variant_list_data = [
         credit: "ilikerandom, named 'dementiago' by ad",
         description: "A variant of blackout in which each objective ticked hides adjacent objectives. Players must instantly tick an objective they believe to have: if that objective is not something they have, they must untick the objective and wait in place for 1 minute. Standard blackout rules apply.",
         notes: "No such plugin currently exists.",
-        color:"Red",
+        color:"Orange",
         tags:["blackout", "cursed", "unplayable"],
         min_teams:1,
         max_teams:null,
@@ -1458,7 +1458,7 @@ let variant_list_data = [
         credit: "FlyingLudicolo",
         description: "A variant of lockout in which every objective is altered so that the objective has to be completed in a specific way or changed to be a more difficult version.",
         notes: "No such generator exists.",
-        color:"Red",
+        color:"Orange",
         tags:["lockout", "custom-generator", "cursed", "difficult", "unplayable"],
         min_teams:2,
         max_teams:2,
@@ -1515,7 +1515,7 @@ let variant_list_data = [
         credit: "rhelmot",
         description: "A variant of lockout in which every character is replaced with *. Every n seconds, players may submit one character for an individual square to reveal those characters. If a player ticks an objective they don't have, the tick goes to the opponent.",
         notes: "No such plugin currently exists. Creator suggests combining this gamemode with bingobuthardtoread.",
-        color:"Red",
+        color:"Orange",
         external_links:[{
             name:"Generator",
             file:"download-files/bingobuthardtoread.json"
@@ -1542,8 +1542,8 @@ let variant_list_data = [
         credit: "creep",
         description: "Two players play on five boards forming a plus sign (+). There are two phases to this game: the Control phase and the Capture phase. During the Control phase, the outer boards are played with Line Control (Row Control for left and right boards, Column Control for the top and bottom boards). For each line controlled, the adjacent square on the central board becomes \"protected\" (opponent cannot capture). Players can choose to complete and tick these protected squares at any moment. The Capture phase begins when all outer boards have no more free rows. All remaining objectives on the central board become unprotected and is played as a modified cheat mode lockout game from a fresh save file. First to tick 13 objectives on the central board wins.",
         notes: "If a corner square is doubly protected by the same player, the tick goes to the player without having to complete the objective. If protected by both, then the square can be ticked by either player. Extremely difficult to manage 5 boards concurrently.",
-        color:"Red",
-        tags:["lockout", "cursed", "difficult", "unplayable"],
+        color:"Orange",
+        tags:["lockout", "cursed", "difficult"],
         min_teams:2,
         max_teams:2,
         min_players_per_team:1,
@@ -1564,7 +1564,7 @@ let variant_list_data = [
         name: "Strawberry Jam Bingo",
         credit: "Tntgobang, maintained by Tntgobang, Nene22, creep, Cookie",
         description: "A variant of lockout bingo played on the 2023 Strawberry Jam mod.",
-        notes: "There is a known bug with the custom progression mod that says the mod assembly failed to load. You can safely ignore this error. Do not use BingoUI with Strawberry Jam Bingo.",
+        notes: "There is a known bug with the custom progression mod that says the mod assembly failed to load. You can safely ignore this error.",
         color:"Green",
         external_links:[
             {

--- a/variant-list.js
+++ b/variant-list.js
@@ -1365,7 +1365,7 @@ let variant_list_data = [
         credit: "ArrowBounce",
         description: "An identical ruleset to Chessgo, except played on a board of Go.",
         notes: "Use the Individual Berry Bingo generator. Playing with cheat mode is recommended. A board size of 9 is recommended for readability. ",
-        color:"Orange",
+        color:"Green",
         tags:["lockout", "cursed"],
         min_teams:2,
         max_teams:2,


### PR DESCRIPTION
Wave of variants included dating back to May 2023. Some variants are not included for inadequate/ambiguous rulesets.

Changes
--------------------------------
[ORANGE -> GREEN] Gogo

Additions
--------------------------------
[ORANGE] Dementiago
[ORANGE] Kryptingo
[ORANGE] Signalgo
[ORANGE] Disconnectedgo
[GREEN] How to Lose at Bingo
[ORANGE] Bingo B-Side
[RED] Bingo but it's actually bingo
[ORANGE] Soulreadgo
[GREEN] Pictionary Ktango
[ORANGE] One word Ktango
[ORANGE] Wheel of Fortune
[BLUE] Scoutout
[ORANGE] Capture the Square
[GREEN] Sunny Reveal
[GREEN] Strawberry Jam Bingo
[ORANGE] Alphabetgo
[GREEN] Control Swap
[ORANGE] Cluelessgo
[ORANGE] Guesswork
[ORANGE] Bingo with Stream Sniping