### PR TITLE
switch to new itch link for wordle bingo

### DIFF
--- a/variant-list.js
+++ b/variant-list.js
@@ -1651,7 +1651,7 @@ let variant_list_data = [
         external_links:[
             {
                 name: "External Tool",
-                link: "https://kipahlord13.itch.io/celeste-wordle-bingo?secret=rG5vctHgLkSqyiKmltGXPiwCo54"
+                link: "https://isaac-ccom.itch.io/wordle-bingo"
             },
             {
                 name: "Ruleset",


### PR DESCRIPTION
switching because old link was potentially associated with other personal data